### PR TITLE
Add Slack Jira update and close ticket support

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -87,6 +87,11 @@ def parse_input(state: OrchestratorState) -> OrchestratorState:
         raw_value  = urllib.parse.unquote_plus(action.get("value", ""))
         
         session_id = raw_value if raw_value and raw_value not in ("", "cancel", "{}") else None
+        value_dict = {}
+        if session_id:
+            value_dict = load_session(session_id) or {}
+            if not value_dict:
+                logger.warning("[trace=%s] session %s expired or missing", trace_id, session_id)
 
         # For confirm_summary: value is direct JSON (not a Redis session ID)
         # For other actions: value is a Redis session ID

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -299,7 +299,7 @@ def router_agent(state: OrchestratorState) -> OrchestratorState:
 
     sys_msg = (
         "You are an intent router for a workplace automation system.\n"
-        "  'slack'  — Slack message asking to create a Jira task\n"
+        "  'slack'  — Slack message asking to create, update, close, resolve, assign, comment on, or modify a Jira ticket\n"
         "  'email'  — email containing meeting scheduling intent\n"
         "  'none'   — not actionable\n"
         "Return a RouterDecision JSON."

--- a/src/slack_agent.py
+++ b/src/slack_agent.py
@@ -298,9 +298,6 @@ def slack_update_jira(state: OrchestratorState) -> OrchestratorState:
         # 1. Update editable fields
         fields = {}
 
-        if summary:
-            fields["summary"] = summary
-
         if fields:
             update_resp = requests.put(
                 f"{JIRA_BASE_URL}/rest/api/3/issue/{issue_key}",

--- a/src/slack_agent.py
+++ b/src/slack_agent.py
@@ -1,33 +1,29 @@
 """
 slack_agent.py — Slack + Jira subgraph
 =======================================
-Nodes:
-  slack_extract_ticket   — LLM extracts a Jira ticket from the Slack message
-  slack_post_preview     — Posts proposed ticket card with Approve/Cancel buttons
-  slack_resolve_assignee — Maps raw assignee string → Jira account ID via TEAM_MAP
-  slack_create_jira      — Calls the Jira REST API to create the issue
-  slack_post_result      — Updates the Slack message with the final outcome
-  slack_post_cancel      — Updates the Slack message with a cancellation notice
-
-Entry routing (route_slack_entry):
-  - url_verification  → __end__  (handled at orchestrator level)
-  - interactivity + create_jira → slack_resolve_assignee
-  - interactivity + cancel_jira → slack_post_cancel
-  - message           → slack_extract_ticket
+Supports:
+  - Create Jira ticket
+  - Update Jira ticket
+  - Close Jira ticket
+  - Slack preview + confirm/cancel
+  - Redis feedback/session tracking
 """
 
-import json, logging
-from redis_store import save_session, record_feedback
+import json
+import logging
+from functools import wraps
+from typing import Literal
 
 import requests
 from requests.auth import HTTPBasicAuth
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from pydantic import BaseModel, Field
-from typing import Literal
 
 from langchain_core.messages import SystemMessage, HumanMessage
 from langgraph.graph import StateGraph, START, END
+
+from redis_store import save_session, record_feedback
 
 from state import (
     OrchestratorState,
@@ -39,76 +35,133 @@ from state import (
 
 logger = logging.getLogger(__name__)
 
-from functools import wraps
-import logging
-
-logger = logging.getLogger(__name__)
 
 def _logged_slack(client: WebClient) -> WebClient:
-    """Wrap every Slack API method to log the call and args before executing."""
+    """Wrap Slack API calls for safer logging."""
     original_api_call = client.api_call
 
     @wraps(original_api_call)
     def logged_api_call(api_method, *args, **kwargs):
-        # Log the method name and all arguments
         safe_kwargs = {
             k: (v[:50] + "..." if isinstance(v, str) and len(v) > 50 else v)
             for k, v in kwargs.items()
-            if k not in ("token",)  # never log the token
+            if k not in ("token",)
         }
         logger.info(f"SLACK API CALL  : {api_method}")
         logger.info(f"SLACK API ARGS  : {safe_kwargs}")
         result = original_api_call(api_method, *args, **kwargs)
-        logger.info(f"SLACK API RESULT: ok={result.get('ok')} error={result.get('error','none')}")
+        logger.info(f"SLACK API RESULT: ok={result.get('ok')} error={result.get('error', 'none')}")
         return result
 
     client.api_call = logged_api_call
     return client
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Structured output schema
 # ─────────────────────────────────────────────────────────────────────────────
+
 class JiraTicket(BaseModel):
-    task_summary: str = Field(description="Brief summary of the task")
-    assignee: str = Field(default="Unassigned", description="Slack User ID or name mentioned")
+    action: Literal["create", "update", "close", "no_action"] = "no_action"
+    task_summary: str | None = Field(default=None, description="Brief summary of the task")
+    assignee: str | None = Field(default="Unassigned", description="Slack User ID or name mentioned")
+    issue_key: str | None = Field(default=None, description="Existing Jira issue key like KAN-123")
+    status: str | None = Field(default=None, description="Updated status if mentioned")
+    comment: str | None = Field(default=None, description="Comment or update note if mentioned")
     no_action: bool = Field(default=False, description="True if no actionable task found")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Nodes
 # ─────────────────────────────────────────────────────────────────────────────
+
 def slack_extract_ticket(state: OrchestratorState) -> OrchestratorState:
-    """LLM extracts a structured Jira ticket from the Slack message text."""
-    sys_msg = (
-        "You are a Jira assistant. Extract task details from the user's Slack message. "
-        "For 'assignee', return the Slack User ID or name. "
-        "Set no_action=True if the message contains no actionable task."
-    )
+    """LLM extracts a structured Jira action from Slack message text."""
+    sys_msg = """
+You are a Jira assistant.
+
+Classify the user's Slack message into one of these actions:
+- create: create a new Jira ticket
+- update: update an existing Jira ticket
+- close: close or resolve an existing Jira ticket
+- no_action: no Jira action needed
+
+Rules:
+- If the message contains an issue key like KAN-123, prefer update or close instead of create.
+- If the message says close, resolve, done, completed, fixed, mark done -> action = close.
+- If the message says update, change, modify, assign, add comment -> action = update.
+- If the message describes a new issue/task without an issue key -> action = create.
+- If nothing actionable is present -> action = no_action and no_action = true.
+
+Extract:
+- action
+- task_summary
+- assignee
+- issue_key
+- status
+- comment
+- no_action
+"""
+
     llm = _llm(structured_output=JiraTicket, model_name="slack")
+
     try:
-        ticket: JiraTicket = llm.invoke([SystemMessage(content=sys_msg), HumanMessage(content=state.user_text)])
+        ticket: JiraTicket = llm.invoke([
+            SystemMessage(content=sys_msg),
+            HumanMessage(content=state.user_text),
+        ])
+
         return state.model_copy(update={
             "slack_ticket_summary": ticket.task_summary,
             "slack_ticket_assignee": ticket.assignee,
             "slack_no_action": ticket.no_action,
+            "slack_action_type": ticket.action,
+            "slack_issue_key": ticket.issue_key,
+            "slack_update_status": ticket.status,
+            "slack_comment": ticket.comment,
         })
+
     except Exception as e:
         logger.error(f"Slack extract error: {e}")
         return state.model_copy(update={"error": str(e)})
 
 
 def slack_post_preview(state: OrchestratorState) -> OrchestratorState:
-    """Post the proposed ticket card with Approve / Cancel buttons to Slack."""
+    """Post Jira action preview card with confirm/cancel buttons."""
     client = _logged_slack(WebClient(token=SLACK_BOT_TOKEN))
+
+    action_label = (state.slack_action_type or "create").replace("_", " ").title()
+
+    details = [
+        "🎫 *Proposed Jira Action*",
+        f"*Action:* {action_label}",
+        f"*Summary:* {state.slack_ticket_summary or 'N/A'}",
+        f"*Issue Key:* {state.slack_issue_key or 'New Ticket'}",
+        f"*Assignee:* {state.slack_ticket_assignee or 'Unassigned'}",
+    ]
+
+    if state.slack_update_status:
+        details.append(f"*Status:* {state.slack_update_status}")
+
+    if state.slack_comment:
+        details.append(f"*Comment:* {state.slack_comment}")
+
+    session_id = save_session({
+        "flow": "slack",
+        "s": state.slack_ticket_summary,
+        "a": state.slack_ticket_assignee,
+        "issue_key": state.slack_issue_key,
+        "status": state.slack_update_status,
+        "comment": state.slack_comment,
+        "action": state.slack_action_type,
+    })
+
     blocks = [
         {
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": (
-                    f"🎫 *Proposed Jira Task*\n"
-                    f"*Summary:* {state.slack_ticket_summary}\n"
-                    f"*Assignee:* <@{state.slack_ticket_assignee}>"
-                ),
+                "text": "\n".join(details),
             },
         },
         {
@@ -116,9 +169,9 @@ def slack_post_preview(state: OrchestratorState) -> OrchestratorState:
             "elements": [
                 {
                     "type": "button",
-                    "text": {"type": "plain_text", "text": "✅ Create Ticket"},
+                    "text": {"type": "plain_text", "text": f"✅ Confirm {action_label}"},
                     "style": "primary",
-                    "value": save_session({"flow": "slack", "s": state.slack_ticket_summary, "a": state.slack_ticket_assignee}),
+                    "value": session_id,
                     "action_id": "create_jira",
                 },
                 {
@@ -130,48 +183,68 @@ def slack_post_preview(state: OrchestratorState) -> OrchestratorState:
             ],
         },
     ]
+
     try:
         resp = client.chat_postMessage(
             channel=state.channel_id,
             blocks=blocks,
             thread_ts=state.message_ts,
-            text=f"Proposed Jira Task: {state.slack_ticket_summary}",
+            text=f"Proposed Jira Action: {action_label}",
         )
-        return state.model_copy(update={"preview_ts": resp["ts"]})
+
+        return state.model_copy(update={
+            "preview_ts": resp["ts"],
+            "session_id": session_id,
+        })
+
     except SlackApiError as e:
         return state.model_copy(update={"error": str(e)})
 
 
 def slack_resolve_assignee(state: OrchestratorState) -> OrchestratorState:
-    """Map the raw assignee string → Jira account ID using TEAM_MAP."""
-    raw = (state.slack_action_value or {}).get("a", state.slack_ticket_assignee or "")
+    """Map raw assignee string to Jira account ID using TEAM_MAP."""
+    raw_value = (state.slack_action_value or {}).get("a", state.slack_ticket_assignee)
+    raw = (raw_value or "").strip()
+
     logger.info(f"Resolving assignee: raw='{raw}'")
-    jira_id = TEAM_MAP.get(raw)
-    if not jira_id:
+
+    jira_id = TEAM_MAP.get(raw) if raw else None
+
+    if not jira_id and raw:
         for name, acc_id in TEAM_MAP.items():
-            if name.lower() in raw.lower():
+            if isinstance(name, str) and name.lower() in raw.lower():
                 jira_id = acc_id
                 break
+
     return state.model_copy(update={"jira_account_id": jira_id})
 
 
 def slack_create_jira(state: OrchestratorState) -> OrchestratorState:
-    """Call the Jira REST API to create the issue."""
+    """Create a new Jira issue."""
     summary = (state.slack_action_value or {}).get("s", state.slack_ticket_summary or "")
+
     fields: dict = {
         "project": {"key": JIRA_PROJECT_KEY},
         "summary": summary,
         "description": {
-            "type": "doc", "version": 1,
-            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Created via Slack Agent"}]}],
+            "type": "doc",
+            "version": 1,
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "Created via Slack Agent"}],
+                }
+            ],
         },
         "issuetype": {"name": JIRA_ISSUE_TYPE},
     }
+
     if state.jira_account_id:
         fields["assignee"] = {"id": state.jira_account_id}
 
     try:
         jira_endpoint = f"{JIRA_BASE_URL}/rest/api/3/issue"
+
         safe_summary = (summary[:120] + "...") if len(summary) > 120 else summary
         logger.info(
             "Jira create request: endpoint=%s project=%s issue_type=%s assignee_id=%s summary=%s",
@@ -189,7 +262,9 @@ def slack_create_jira(state: OrchestratorState) -> OrchestratorState:
             auth=HTTPBasicAuth(JIRA_EMAIL, JIRA_API_TOKEN),
             timeout=30,
         )
+
         logger.info("Jira create response status=%s", resp.status_code)
+
         try:
             result = resp.json()
         except ValueError:
@@ -197,120 +272,410 @@ def slack_create_jira(state: OrchestratorState) -> OrchestratorState:
 
         logger.info("Jira create response body=%s", json.dumps(result, ensure_ascii=True))
 
-        if not resp.ok:
-            error_messages = result.get("errorMessages", []) if isinstance(result, dict) else []
-            error_fields = result.get("errors", {}) if isinstance(result, dict) else {}
-            logger.error(
-                "Jira create failed: status=%s errorMessages=%s errors=%s",
-                resp.status_code,
-                error_messages,
-                error_fields,
-            )
-            if any("permission" in msg.lower() for msg in error_messages if isinstance(msg, str)):
-                logger.error(
-                    "Jira permission issue detected for project=%s user=%s",
-                    JIRA_PROJECT_KEY,
-                    JIRA_EMAIL,
-                )
-
         if "key" in result:
             return state.model_copy(update={"jira_key": result["key"]})
-        return state.model_copy(update={"error": json.dumps({"status": resp.status_code, "body": result})})
+
+        return state.model_copy(update={
+            "error": json.dumps({"status": resp.status_code, "body": result})
+        })
+
     except Exception as e:
         logger.exception("Jira create exception")
         return state.model_copy(update={"error": str(e)})
 
 
-def slack_post_result(state: OrchestratorState) -> OrchestratorState:
-    """Update the Slack preview message with the final outcome."""
-    if state.session_id:
-        if state.jira_key:
-            record_feedback(state.session_id, "accepted", {
-                "jira_key":     state.jira_key,
-                "jira_url":     f"{JIRA_BASE_URL}/browse/{state.jira_key}",
-                "summary":      (state.slack_action_value or {}).get("s"),
-                "assignee":     (state.slack_action_value or {}).get("a"),
-            })
-        else:
-            record_feedback(state.session_id, "failed", {"reason": state.error or "jira_create_error"})
+def slack_update_jira(state: OrchestratorState) -> OrchestratorState:
+    """Update an existing Jira issue."""
+    issue_key = state.slack_issue_key or (state.slack_action_value or {}).get("issue_key")
+    summary = state.slack_ticket_summary or (state.slack_action_value or {}).get("s")
+    status = state.slack_update_status or (state.slack_action_value or {}).get("status")
+    comment = state.slack_comment or (state.slack_action_value or {}).get("comment")
 
-    client = _logged_slack(WebClient(token=SLACK_BOT_TOKEN))
-    msg = (
-        f"✅ *Ticket Created:* <{JIRA_BASE_URL}/browse/{state.jira_key}|{state.jira_key}>"
-        if state.jira_key
-        else f"⚠️ Failed: {state.error or 'Unknown error'}"
-    )
+    if not issue_key:
+        return state.model_copy(update={"error": "Missing issue key for update"})
+
     try:
-        client.chat_update(channel=state.channel_id, ts=state.preview_ts, text=msg, blocks=None)
-    except SlackApiError as e:
-        logger.error(f"Slack update error: {e}")
-    return state
+        # 1. Update editable fields
+        fields = {}
+
+        if summary:
+            fields["summary"] = summary
+
+        if fields:
+            update_resp = requests.put(
+                f"{JIRA_BASE_URL}/rest/api/3/issue/{issue_key}",
+                json={"fields": fields},
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                auth=HTTPBasicAuth(JIRA_EMAIL, JIRA_API_TOKEN),
+                timeout=30,
+            )
+
+            if update_resp.status_code not in (200, 204):
+                try:
+                    err_body = update_resp.json()
+                except ValueError:
+                    err_body = update_resp.text
+
+                return state.model_copy(update={
+                    "error": f"Jira update failed ({update_resp.status_code}): {err_body}"
+                })
+
+        # 2. Add comment if present
+        if comment:
+            comment_payload = {
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": comment}],
+                        }
+                    ],
+                }
+            }
+
+            comment_resp = requests.post(
+                f"{JIRA_BASE_URL}/rest/api/3/issue/{issue_key}/comment",
+                json=comment_payload,
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                auth=HTTPBasicAuth(JIRA_EMAIL, JIRA_API_TOKEN),
+                timeout=30,
+            )
+
+            if comment_resp.status_code not in (200, 201):
+                try:
+                    err_body = comment_resp.json()
+                except ValueError:
+                    err_body = comment_resp.text
+
+                return state.model_copy(update={
+                    "error": f"Jira comment failed ({comment_resp.status_code}): {err_body}"
+                })
+
+        # 3. Transition status if present
+        if status:
+            transitions_resp = requests.get(
+                f"{JIRA_BASE_URL}/rest/api/3/issue/{issue_key}/transitions",
+                headers={"Accept": "application/json"},
+                auth=HTTPBasicAuth(JIRA_EMAIL, JIRA_API_TOKEN),
+                timeout=30,
+            )
+
+            if transitions_resp.status_code != 200:
+                try:
+                    err_body = transitions_resp.json()
+                except ValueError:
+                    err_body = transitions_resp.text
+
+                return state.model_copy(update={
+                    "error": f"Jira transitions fetch failed ({transitions_resp.status_code}): {err_body}"
+                })
+
+            transitions = transitions_resp.json().get("transitions", [])
+
+            matched = next(
+                (t for t in transitions if t.get("name", "").strip().lower() == status.strip().lower()),
+                None,
+            )
+
+            if not matched:
+                available = [t.get("name") for t in transitions]
+                return state.model_copy(update={
+                    "error": f"No Jira transition found for status '{status}'. Available: {available}"
+                })
+
+            transition_resp = requests.post(
+                f"{JIRA_BASE_URL}/rest/api/3/issue/{issue_key}/transitions",
+                json={"transition": {"id": matched["id"]}},
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                auth=HTTPBasicAuth(JIRA_EMAIL, JIRA_API_TOKEN),
+                timeout=30,
+            )
+
+            if transition_resp.status_code not in (200, 204):
+                try:
+                    err_body = transition_resp.json()
+                except ValueError:
+                    err_body = transition_resp.text
+
+                return state.model_copy(update={
+                    "error": f"Jira transition failed ({transition_resp.status_code}): {err_body}"
+                })
+
+        return state
+
+    except Exception as e:
+        logger.exception("Jira update exception")
+        return state.model_copy(update={"error": str(e)})
 
 
-def slack_post_cancel(state: OrchestratorState) -> OrchestratorState:
-    """Update the Slack message to show cancellation."""
+def slack_close_jira(state: OrchestratorState) -> OrchestratorState:
+    """Close an existing Jira issue through workflow transitions."""
+    issue_key = state.slack_issue_key or (state.slack_action_value or {}).get("issue_key")
+    comment = state.slack_comment or (state.slack_action_value or {}).get("comment")
+
+    target_status = (
+        state.slack_update_status
+        or (state.slack_action_value or {}).get("status")
+        or "Done"
+    )
+
+    if not issue_key:
+        return state.model_copy(update={"error": "Missing issue key for close"})
+
+    try:
+        # 1. Optional comment
+        if comment:
+            comment_payload = {
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": comment}],
+                        }
+                    ],
+                }
+            }
+
+            comment_resp = requests.post(
+                f"{JIRA_BASE_URL}/rest/api/3/issue/{issue_key}/comment",
+                json=comment_payload,
+                headers={"Accept": "application/json", "Content-Type": "application/json"},
+                auth=HTTPBasicAuth(JIRA_EMAIL, JIRA_API_TOKEN),
+                timeout=30,
+            )
+
+            if comment_resp.status_code not in (200, 201):
+                try:
+                    err_body = comment_resp.json()
+                except ValueError:
+                    err_body = comment_resp.text
+
+                return state.model_copy(update={
+                    "error": f"Jira close comment failed ({comment_resp.status_code}): {err_body}"
+                })
+
+        # 2. Fetch transitions
+        transitions_resp = requests.get(
+            f"{JIRA_BASE_URL}/rest/api/3/issue/{issue_key}/transitions",
+            headers={"Accept": "application/json"},
+            auth=HTTPBasicAuth(JIRA_EMAIL, JIRA_API_TOKEN),
+            timeout=30,
+        )
+
+        if transitions_resp.status_code != 200:
+            try:
+                err_body = transitions_resp.json()
+            except ValueError:
+                err_body = transitions_resp.text
+
+            return state.model_copy(update={
+                "error": f"Jira transitions fetch failed ({transitions_resp.status_code}): {err_body}"
+            })
+
+        transitions = transitions_resp.json().get("transitions", [])
+
+        preferred_names = [
+            target_status,
+            "Done",
+            "Closed",
+            "Resolved",
+            "Resolve Issue",
+        ]
+
+        matched = None
+
+        for name in preferred_names:
+            matched = next(
+                (t for t in transitions if t.get("name", "").strip().lower() == name.strip().lower()),
+                None,
+            )
+            if matched:
+                break
+
+        if not matched:
+            available = [t.get("name") for t in transitions]
+            return state.model_copy(update={
+                "error": f"No close transition found for issue {issue_key}. Available: {available}"
+            })
+
+        # 3. Perform transition
+        transition_resp = requests.post(
+            f"{JIRA_BASE_URL}/rest/api/3/issue/{issue_key}/transitions",
+            json={"transition": {"id": matched["id"]}},
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+            auth=HTTPBasicAuth(JIRA_EMAIL, JIRA_API_TOKEN),
+            timeout=30,
+        )
+
+        if transition_resp.status_code not in (200, 204):
+            try:
+                err_body = transition_resp.json()
+            except ValueError:
+                err_body = transition_resp.text
+
+            return state.model_copy(update={
+                "error": f"Jira close transition failed ({transition_resp.status_code}): {err_body}"
+            })
+
+        return state
+
+    except Exception as e:
+        logger.exception("Jira close exception")
+        return state.model_copy(update={"error": str(e)})
+
+
+def slack_post_result(state: OrchestratorState) -> OrchestratorState:
+    """Update Slack preview with final Jira action result."""
+    action = state.slack_action_type or (state.slack_action_value or {}).get("action")
+    issue_key = state.slack_issue_key or (state.slack_action_value or {}).get("issue_key")
+
     if state.session_id:
-        record_feedback(state.session_id, "rejected")
+        if state.error:
+            record_feedback(state.session_id, "failed", {"reason": state.error})
+        else:
+            record_feedback(state.session_id, "accepted", {
+                "action": action,
+                "jira_key": state.jira_key or issue_key,
+                "jira_url": f"{JIRA_BASE_URL}/browse/{state.jira_key or issue_key}",
+                "summary": (state.slack_action_value or {}).get("s"),
+                "assignee": (state.slack_action_value or {}).get("a"),
+            })
 
     client = _logged_slack(WebClient(token=SLACK_BOT_TOKEN))
+
+    if state.error:
+        msg = f"⚠️ Failed: {state.error}"
+    elif action == "create":
+        msg = f"✅ *Ticket Created:* <{JIRA_BASE_URL}/browse/{state.jira_key}|{state.jira_key}>"
+    elif action == "update":
+        msg = f"✏️ *Ticket Updated:* {issue_key}"
+    elif action == "close":
+        msg = f"✅ *Ticket Closed:* {issue_key}"
+    else:
+        msg = "⚠️ Unknown Jira action result"
+
     try:
         client.chat_update(
             channel=state.channel_id,
             ts=state.preview_ts,
-            text="❌ Ticket creation cancelled.",
+            text=msg,
             blocks=None,
         )
+
+    except SlackApiError as e:
+        logger.error(f"Slack update error: {e}")
+
+    return state
+
+
+def slack_post_cancel(state: OrchestratorState) -> OrchestratorState:
+    """Update Slack message to show cancellation."""
+    if state.session_id:
+        record_feedback(state.session_id, "rejected")
+
+    client = _logged_slack(WebClient(token=SLACK_BOT_TOKEN))
+
+    try:
+        client.chat_update(
+            channel=state.channel_id,
+            ts=state.preview_ts,
+            text="❌ Jira action cancelled.",
+            blocks=None,
+        )
+
     except SlackApiError as e:
         logger.error(f"Slack cancel error: {e}")
+
     return state
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Routing
 # ─────────────────────────────────────────────────────────────────────────────
+
 def route_slack_entry(state: OrchestratorState) -> Literal[
     "slack_extract_ticket", "slack_resolve_assignee", "slack_post_cancel", "__end__"
 ]:
     if state.slack_event_type == "url_verification":
         return "__end__"
+
     if state.slack_event_type == "interactivity":
         if state.slack_action_id == "create_jira":
             return "slack_resolve_assignee"
         return "slack_post_cancel"
+
     return "slack_extract_ticket"
 
 
 def route_after_extract(state: OrchestratorState) -> Literal["slack_post_preview", "__end__"]:
     if state.error or state.slack_no_action:
         return "__end__"
+
     return "slack_post_preview"
+
+
+def route_jira_action(state: OrchestratorState) -> Literal[
+    "slack_create_jira", "slack_update_jira", "slack_close_jira", "slack_post_cancel"
+]:
+    action = state.slack_action_type or (state.slack_action_value or {}).get("action")
+
+    if action == "create":
+        return "slack_create_jira"
+
+    if action == "update":
+        return "slack_update_jira"
+
+    if action == "close":
+        return "slack_close_jira"
+
+    return "slack_post_cancel"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Subgraph builder
 # ─────────────────────────────────────────────────────────────────────────────
+
 def build_slack_subgraph() -> StateGraph:
     b = StateGraph(OrchestratorState)
-    b.add_node("slack_extract_ticket",   slack_extract_ticket)
-    b.add_node("slack_post_preview",     slack_post_preview)
+
+    b.add_node("slack_extract_ticket", slack_extract_ticket)
+    b.add_node("slack_post_preview", slack_post_preview)
     b.add_node("slack_resolve_assignee", slack_resolve_assignee)
-    b.add_node("slack_create_jira",      slack_create_jira)
-    b.add_node("slack_post_result",      slack_post_result)
-    b.add_node("slack_post_cancel",      slack_post_cancel)
+    b.add_node("slack_create_jira", slack_create_jira)
+    b.add_node("slack_update_jira", slack_update_jira)
+    b.add_node("slack_close_jira", slack_close_jira)
+    b.add_node("slack_post_result", slack_post_result)
+    b.add_node("slack_post_cancel", slack_post_cancel)
 
     b.add_conditional_edges(START, route_slack_entry, {
-        "slack_extract_ticket":   "slack_extract_ticket",
+        "slack_extract_ticket": "slack_extract_ticket",
         "slack_resolve_assignee": "slack_resolve_assignee",
-        "slack_post_cancel":      "slack_post_cancel",
-        "__end__":                END,
+        "slack_post_cancel": "slack_post_cancel",
+        "__end__": END,
     })
+
     b.add_conditional_edges("slack_extract_ticket", route_after_extract, {
         "slack_post_preview": "slack_post_preview",
-        "__end__":            END,
+        "__end__": END,
     })
-    b.add_edge("slack_post_preview",     END)
-    b.add_edge("slack_resolve_assignee", "slack_create_jira")
-    b.add_edge("slack_create_jira",      "slack_post_result")
-    b.add_edge("slack_post_result",      END)
-    b.add_edge("slack_post_cancel",      END)
+
+    b.add_edge("slack_post_preview", END)
+
+    b.add_conditional_edges("slack_resolve_assignee", route_jira_action, {
+        "slack_create_jira": "slack_create_jira",
+        "slack_update_jira": "slack_update_jira",
+        "slack_close_jira": "slack_close_jira",
+        "slack_post_cancel": "slack_post_cancel",
+    })
+
+    b.add_edge("slack_create_jira", "slack_post_result")
+    b.add_edge("slack_update_jira", "slack_post_result")
+    b.add_edge("slack_close_jira", "slack_post_result")
+    b.add_edge("slack_post_result", END)
+    b.add_edge("slack_post_cancel", END)
+
     return b.compile()

--- a/src/state.py
+++ b/src/state.py
@@ -107,6 +107,10 @@ class OrchestratorState(BaseModel):
     slack_action_value: Optional[dict] = None
     jira_account_id: Optional[str] = None
     jira_key: Optional[str] = None
+    slack_action_type: Optional[str] = None
+    slack_issue_key: Optional[str] = None
+    slack_update_status: Optional[str] = None
+    slack_comment: Optional[str] = None
 
     # ── Email/Calendar-specific ────────────────────────────────────────────
     email_source: Literal["pubsub", "direct", "unknown"] = "unknown"


### PR DESCRIPTION
Implemented Slack Jira enhancement to support create, update, close, and assignee mapping.

Tested:
- Create Jira ticket from Slack
- Assign ticket using TEAM_MAP_JSON
- Update status to In Progress
- Preserve Jira summary during update
- Close ticket to Done
- Slack confirm/cancel flow